### PR TITLE
Changed reference to i3 in file path to sway

### DIFF
--- a/sway_workspaces.py
+++ b/sway_workspaces.py
@@ -18,7 +18,7 @@ if sh:
         dunstify = None
         notifysend = sh.Command('notify-send')
 
-PATH = os.path.expanduser('~/.config/i3/workspace_')
+PATH = os.path.expanduser('~/.config/sway/workspace_')
 workspace_mapping = None
 appname = sys.argv[0]
 


### PR DESCRIPTION
The file path refers to `~/.config/i3/workspace_`. As this script pertains to sway, it should point to `~/.config/sway/workspace_`.