### PR TITLE
Prevent containers from moving when already on correct workspace

### DIFF
--- a/sway_workspaces.py
+++ b/sway_workspaces.py
@@ -137,7 +137,7 @@ if __name__ == '__main__':
                     else:
                         o = 'v'
                     tree_app.command(f'split {o}')
-                    tree_app.command(f'move container to workspace {ws_name}')
+                    tree_app.command(f'move --no-auto-back-and-forth container to workspace {ws_name}')
 
         # Move workspaces to outputs
         for workspace in workspace_mapping:

--- a/sway_workspaces.py
+++ b/sway_workspaces.py
@@ -21,14 +21,15 @@ else:
     dunstify = None
     notifysend = None
 
-if os.path.isdir(os.path.expanduser('~/.sway/config')):
-    PATH = os.path.expanduser('~/.sway/config/workspace_')
-elif os.path.isdir(os.path.expanduser('~/.config/sway')):
-    PATH = os.path.expanduser('~/.config/sway/workspace_')
-elif os.path.isdir(os.path.expanduser('~/.i3/config')):
-    PATH = os.path.expanduser('~/.i3/config/workspace_')
-elif os.path.isdir(os.path.expanduser('~/.config/i3')):
-    PATH = os.path.expanduser('~/.config/i3/workspace_')
+home_folder = os.path.expanduser('~')
+if os.path.isdir(home_folder + '/.sway/config'):
+    PATH = home_folder + '/.sway/config/workspace_'
+elif os.path.isdir(home_folder + '/.config/sway'):
+    PATH = home_folder + '/.config/sway/workspace_'
+elif os.path.isdir(home_folder + '/.i3/config'):
+    PATH = home_folder + '/.i3/config/workspace_'
+elif os.path.isdir(home_folder + '/.config/i3'):
+    PATH = home_folder + '/.config/i3/workspace_'
 else:
     PATH = None
 

--- a/sway_workspaces.py
+++ b/sway_workspaces.py
@@ -21,7 +21,17 @@ else:
     dunstify = None
     notifysend = None
 
-PATH = os.path.expanduser('~/.config/sway/workspace_')
+if os.path.isdir(os.path.expanduser('~/.sway/config')):
+    PATH = os.path.expanduser('~/.sway/config/workspace_')
+elif os.path.isdir(os.path.expanduser('~/.config/sway')):
+    PATH = os.path.expanduser('~/.config/sway/workspace_')
+elif os.path.isdir(os.path.expanduser('~/.i3/config')):
+    PATH = os.path.expanduser('~/.i3/config/workspace_')
+elif os.path.isdir(os.path.expanduser('~/.config/i3')):
+    PATH = os.path.expanduser('~/.config/i3/workspace_')
+else:
+    PATH = None
+
 workspace_mapping = None
 appname = sys.argv[0]
 


### PR DESCRIPTION
If you run `move container to workspace {ws_name}` without the `--no-auto-back-and-forth` flag and the container being moved is on the correct workspace, it will be moved to the wrong workspace.